### PR TITLE
Don't use x86 lzma filter unconditionally

### DIFF
--- a/src/mardor/utils.py
+++ b/src/mardor/utils.py
@@ -142,7 +142,7 @@ def bz2_decompress_stream(src):
             yield decoded
 
 
-def xz_compress_stream(src):
+def xz_compress_stream(src, bcj=None):
     """Compress data from `src`.
 
     Args:
@@ -152,13 +152,17 @@ def xz_compress_stream(src):
         blocks of compressed data
 
     """
-    compressor = lzma.LZMACompressor(
-        check=lzma.CHECK_CRC64,
-        filters=[
-            {"id": lzma.FILTER_X86},
+    filters = []
+    if bcj == "x86":
+        filters.append({"id": lzma.FILTER_X86})
+    filters.extend([
             {"id": lzma.FILTER_LZMA2,
              "preset": lzma.PRESET_DEFAULT},
         ])
+    compressor = lzma.LZMACompressor(
+        check=lzma.CHECK_CRC64,
+        filters=filters,
+    )
     for block in src:
         encoded = compressor.compress(block)
         if encoded:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -207,11 +207,14 @@ def test_adddir_as_file(tmpdir):
 def test_xz_writer(tmpdir):
     message_p = tmpdir.join('message.txt')
     message_p.write('hello world')
+    x86_message_p = tmpdir.join('message_x86.txt')
+    x86_message_p.write('hello world')
     mar_p = tmpdir.join('test.mar')
     with mar_p.open('wb') as f:
         with MarWriter(f) as m:
             with tmpdir.as_cwd():
                 m.add('message.txt', compress='xz')
+                m.add('message_x86.txt', compress='xz', bcj='x86')
 
     assert mar_p.size() > 0
 
@@ -219,10 +222,13 @@ def test_xz_writer(tmpdir):
         with MarReader(f) as m:
             assert m.mardata.additional is None
             assert m.mardata.signatures is None
-            assert len(m.mardata.index.entries) == 1
+            assert len(m.mardata.index.entries) == 2
             assert m.mardata.index.entries[0].name == 'message.txt'
+            assert m.mardata.index.entries[1].name == 'message_x86.txt'
             m.extract(str(tmpdir.join('extracted')))
             assert (tmpdir.join('extracted', 'message.txt').read('rb') ==
+                    b'hello world')
+            assert (tmpdir.join('extracted', 'message_x86.txt').read('rb') ==
                     b'hello world')
 
 


### PR DESCRIPTION
Add a command-line option and API to set the lzma BCJ filter, and don't use one by default.

Fixes #63